### PR TITLE
Implementiere Passwort-Reset-Funktionalität

### DIFF
--- a/server/api/model/user.go
+++ b/server/api/model/user.go
@@ -5,6 +5,11 @@ type RegistrationLoginRequest struct {
 	Password string `json:"password" form:"password"`
 }
 
+type ResetPasswordRequest struct {
+	OldPassword string `json:"oldpassword" form:"oldpassword"`
+	NewPassword string `json:"newpassword" form:"newpassword"`
+}
+
 type UserRequest struct {
 	Firstname *string `json:"firstname" form:"firstname"`
 	Lastname  *string `json:"lastname" form:"lastname"`

--- a/server/api/response.go
+++ b/server/api/response.go
@@ -13,3 +13,7 @@ func RecordResponse(e *core.RequestEvent, r *core.Record) error {
 func EmptyResponse(e *core.RequestEvent) error {
 	return e.JSON(http.StatusOK, struct{}{})
 }
+
+func TokenResponse(e *core.RequestEvent, token *string) error {
+	return e.JSON(http.StatusOK, map[string]string{"token": *token})
+}

--- a/server/store/users.go
+++ b/server/store/users.go
@@ -48,6 +48,27 @@ func (d *UserStore) CreateNew(email, password string) (*db.User, error) {
 	return user, nil
 }
 
+func (d *UserStore) ResetPassword(auth *core.Record, oldPassword, newPassword string) (*string, error) {
+
+	if auth.ValidatePassword(oldPassword) == false {
+		return nil, errors.New("error_reset_password")
+	}
+
+	app := (*d.app)
+
+	auth.SetPassword(newPassword)
+	if err := app.Save(auth); err != nil {
+		return nil, errors.New("error_reset_password")
+	}
+
+	token, err := auth.NewAuthToken()
+	if err != nil {
+		return nil, errors.New("error_reset_password")
+	}
+
+	return &token, nil
+}
+
 func (d *UserStore) UpdateUser(auth *core.Record, input *model.UserRequest) error {
 
 	app := (*d.app)


### PR DESCRIPTION
Füge die Funktionalität zum Zurücksetzen von Passwörtern hinzu. 
Erstelle die `ResetPassword`-Methode im `UserStore`, die das alte Passwort validiert und das neue Passwort speichert. 
Ergänze die API mit der `resetPassword`-Methode, um Anfragen zu verarbeiten und ein Token zurückzugeben.