### PR TITLE
Implementiere GET Posts

### DIFF
--- a/server/api/model/post.go
+++ b/server/api/model/post.go
@@ -1,6 +1,10 @@
 package model
 
 type CreatePostRequest struct {
-	Title       string `json:"title"`
 	Description string `json:"description"`
+}
+
+type PaginatedPosts struct {
+	Take int `json:"take"`
+	Skip int `json:"skip"`
 }

--- a/server/api/response.go
+++ b/server/api/response.go
@@ -6,8 +6,23 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 )
 
-func RecordResponse(e *core.RequestEvent, r *core.Record) error {
-	return e.JSON(http.StatusOK, r.WithCustomData(true).PublicExport())
+func RecordResponse(e *core.RequestEvent, r *core.Record, includeCustom ...bool) error {
+	inc := getIncludeCustomData(includeCustom...)
+	return e.JSON(http.StatusOK, r.
+		WithCustomData(inc).
+		PublicExport())
+}
+
+func MultipleRecordResponse(e *core.RequestEvent, r []*core.Record, includeCustom ...bool) error {
+
+	inc := getIncludeCustomData(includeCustom...)
+
+	items := []map[string]any{}
+	for i := 0; i < len(r); i++ {
+		items = append(items, r[i].WithCustomData(inc).PublicExport())
+	}
+
+	return e.JSON(http.StatusOK, items)
 }
 
 func EmptyResponse(e *core.RequestEvent) error {
@@ -16,4 +31,13 @@ func EmptyResponse(e *core.RequestEvent) error {
 
 func TokenResponse(e *core.RequestEvent, token *string) error {
 	return e.JSON(http.StatusOK, map[string]string{"token": *token})
+}
+
+func getIncludeCustomData(includeCustom ...bool) bool {
+	inc := true
+	if len(includeCustom) > 0 {
+		inc = includeCustom[0]
+	}
+
+	return inc
 }

--- a/server/store/db/post.go
+++ b/server/store/db/post.go
@@ -10,20 +10,20 @@ type Post struct {
 	core.BaseRecordProxy
 }
 
-func (u *Post) GetTitle() string {
-	return u.GetString("title")
-}
-
-func (u *Post) SetTitle(title *string) {
-	u.Set("title", title)
-}
-
 func (u *Post) GetDescription() string {
 	return u.GetString("description")
 }
 
 func (u *Post) SetDescription(description *string) {
 	u.Set("description", description)
+}
+
+func (u *Post) GetActive() bool {
+	return u.GetBool("active")
+}
+
+func (u *Post) SetActive(active bool) {
+	u.Set("active", active)
 }
 
 func (p *Post) GetCreatedBy() string {

--- a/server/store/posts.go
+++ b/server/store/posts.go
@@ -33,14 +33,31 @@ func (d *PostStore) CreatePost(auth *core.Record, data *model.CreatePostRequest)
 	post := &db.Post{}
 	post.SetProxyRecord(core.NewRecord(postsCollection))
 
-	post.SetTitle(&data.Title)
 	post.SetDescription(&data.Description)
 	post.SetCreatedBy(auth.Id)
 	post.SetUpdatedBy(auth.Id)
+	post.SetActive(true)
 
 	if err = app.Save(post); err != nil {
 		return nil, err
 	}
 
 	return post.Record, nil
+}
+
+func (s *PostStore) GetPosts(take, skip int) ([]*core.Record, error) {
+
+	app := (*s.app)
+
+	records, err := app.FindRecordsByFilter(s.TableName(),
+		"active = TRUE",
+		"-created",
+		take,
+		skip)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return records, err
 }


### PR DESCRIPTION
Füge die Funktionalität zur Paginierung von Posts hinzu. 
Erstelle die Methode `getPaginated`, um Posts basierend auf 
`take` und `skip` abzurufen. Entferne die Titel-Setzung 
aus `CreatePost`, um die Struktur zu vereinfachen. 
Erweitere die Antwortfunktionen, um benutzerdefinierte 
Daten optional einzuschließen.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #8 
- <kbd>&nbsp;1&nbsp;</kbd> #7 👈 
<!-- GitButler Footer Boundary Bottom -->

