### PR TITLE
Ändere API-Bindungen

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,8 +12,8 @@ func main() {
 	app := pocketbase.New()
 
 	app.OnServe().BindFunc(func(e *core.ServeEvent) error {
-		api.BindUsersApi(e)
-		api.BindPostsApi(e)
+		userApi := api.BindUsersApi(e)
+		_ = api.BindPostsApi(e, userApi)
 
 		return e.Next()
 	})

--- a/server/api/posts.go
+++ b/server/api/posts.go
@@ -13,10 +13,10 @@ type PostApi struct {
 	store *store.PostStore
 }
 
-func BindPostsApi(se *core.ServeEvent) {
+func BindPostsApi(se *core.ServeEvent, userApi *UserApi) *PostApi {
 
 	api := &PostApi{
-		store: store.BuildPostStore(se),
+		store: store.BuildPostStore(se, userApi.store),
 	}
 
 	// Auth
@@ -24,6 +24,8 @@ func BindPostsApi(se *core.ServeEvent) {
 	grp.Bind(apis.RequireAuth(), RequireLockoutMiddleware())
 	grp.POST("/new", api.createNewPost)
 	grp.GET("", api.getPaginated)
+
+	return api
 }
 
 func (a *PostApi) createNewPost(e *core.RequestEvent) error {

--- a/server/api/users.go
+++ b/server/api/users.go
@@ -12,7 +12,7 @@ type UserApi struct {
 	store *store.UserStore
 }
 
-func BindUsersApi(se *core.ServeEvent) {
+func BindUsersApi(se *core.ServeEvent) *UserApi {
 
 	api := &UserApi{
 		store: store.BuildUserStore(se),
@@ -29,6 +29,8 @@ func BindUsersApi(se *core.ServeEvent) {
 	grp.POST("/resetpassword", api.resetPassword)
 	grp.GET("/me", api.getCurrentUser)
 	grp.PUT("", api.updateUser)
+
+	return api
 }
 
 func (a *UserApi) registerNewUser(e *core.RequestEvent) error {

--- a/server/store/posts.go
+++ b/server/store/posts.go
@@ -12,14 +12,16 @@ import (
 type PostStore struct {
 	app        *core.App
 	imageStore *ImageStore
+	userStore  *UserStore
 }
 
-func BuildPostStore(se *core.ServeEvent) *PostStore {
+func BuildPostStore(se *core.ServeEvent, userStore *UserStore) *PostStore {
 	return &PostStore{
 		app: &se.App,
 		imageStore: &ImageStore{
 			app: &se.App,
 		},
+		userStore: userStore,
 	}
 }
 


### PR DESCRIPTION
- Passe BindPostsApi an, um UserApi zu integrieren
- Übergebe UserStore an PostStore
- Stelle sicher, dass Authentifizierung und Middleware korrekt angewendet werden
- Verbessere die Struktur der API-Initialisierung