### PR TITLE
Refactor erweitern der Records

### DIFF
--- a/server/store/users.go
+++ b/server/store/users.go
@@ -102,6 +102,23 @@ func (d *UserStore) UpdateUser(auth *core.Record, input *model.UserRequest) erro
 	return nil
 }
 
+func (s *UserStore) GetPosters(relCollection *core.Collection, relIds []string) ([]*core.Record, error) {
+	app := (*s.app)
+
+	var records []*core.Record
+	records, err := app.FindRecordsByIds(s.TableName(), relIds)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range records {
+		r = r.Hide(db.User_Bio)
+	}
+
+	return records, nil
+}
+
 func IsLockoutEnabled(auth *core.Record) bool {
 	user := &db.User{}
 	user.SetProxyRecord(auth)


### PR DESCRIPTION
- Beim Abrufen der Posts werden Ersteller und Images erweitert.
- Funktion zum Erweitern verschiedener Relations hinzugefügt.
- Die GetPosters Funktion erstellt, welche die Benutzer anhand ihrer Ids abruft.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #13 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #12 
<!-- GitButler Footer Boundary Bottom -->

