### PR TITLE
Bilder speichern und abrufen

### DIFF
--- a/server/api/model/post.go
+++ b/server/api/model/post.go
@@ -1,5 +1,11 @@
 package model
 
 type CreatePostRequest struct {
-	Description string `json:"description"`
+	Description string               `json:"description"`
+	Images      []CreateImageRequest `json:"images"`
+}
+
+type CreateImageRequest struct {
+	Base64 string `json:"base64"`
+	Order  int    `json:"order"`
 }

--- a/server/store/db/image.go
+++ b/server/store/db/image.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/filesystem"
 )
 
 var _ core.RecordProxy = (*Image)(nil)
@@ -52,4 +53,8 @@ func (p *Image) GetUpdatedBy() string {
 
 func (p *Image) SetUpdatedBy(id string) {
 	p.Set(Image_UpdatedBy, id)
+}
+
+func (p *Image) SetImageRaw(f *filesystem.File) {
+	p.Set(Image_Raw, f)
 }

--- a/server/store/db/post.go
+++ b/server/store/db/post.go
@@ -49,3 +49,11 @@ func (p *Post) GetUpdatedBy() string {
 func (p *Post) SetUpdatedBy(id string) {
 	p.Set(Post_UpdatedBy, id)
 }
+
+func (p *Post) GetImages() []string {
+	return p.Get(Post_Images).([]string)
+}
+
+func (p *Post) SetImages(ids *[]string) {
+	p.Set(Post_Images, *ids)
+}

--- a/server/store/images.go
+++ b/server/store/images.go
@@ -3,12 +3,13 @@ package store
 import (
 	"bytes"
 	"encoding/base64"
-	"fmt"
 	"io"
 	"pinking-go/server/store/db"
 
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/filesystem"
+	"github.com/pocketbase/pocketbase/tools/security"
 )
 
 type ImageStore struct {
@@ -25,13 +26,42 @@ func (d *ImageStore) TableName() string {
 	return "images"
 }
 
+func (s *ImageStore) CreateImage(auth *core.Record, base64Str *string, order int) (*core.Record, error) {
+	app := (*s.app)
+
+	imageCollection, err := app.FindCollectionByNameOrId(s.TableName())
+	if err != nil {
+		return nil, err
+	}
+
+	image := &db.Image{}
+	image.SetProxyRecord(core.NewRecord(imageCollection))
+
+	image.SetCreatedBy(auth.Id)
+	image.SetUpdatedBy(auth.Id)
+	image.SetActive(true)
+	image.SetOrder(order)
+
+	f, err := s.newFile(base64Str)
+	if err != nil {
+		return nil, err
+	}
+
+	image.SetImageRaw(f)
+	if err := app.Save(image); err != nil {
+		return nil, err
+	}
+
+	return image.Record, nil
+}
+
 func (s *ImageStore) GetImagesForPosts(relCollection *core.Collection, relIds []string) ([]*core.Record, error) {
 
 	app := (*s.app)
 
 	var records []*core.Record
 	records, err := app.FindRecordsByIds(s.TableName(), relIds, func(q *dbx.SelectQuery) error {
-		q.AndWhere(dbx.NewExp(db.Image_Active+" = {:active}", dbx.Params{db.Image_Active: true}))
+		q.AndWhere(dbx.NewExp(db.Image_Active+" = {:active}", dbx.Params{"active": true}))
 		q.OrderBy(db.Image_Order + " ASC")
 		return nil
 	})
@@ -43,17 +73,24 @@ func (s *ImageStore) GetImagesForPosts(relCollection *core.Collection, relIds []
 	for _, r := range records {
 		img := &db.Image{}
 		img.SetProxyRecord(r)
-		buf, err := s.getRawImage(img)
+		base64Str, err := s.getRawImageBase64(img)
 		if err != nil {
-			fmt.Printf("ERROR %v\n", err)
 			return nil, err
 		}
-		base64Str := base64.StdEncoding.EncodeToString(buf.Bytes())
 		img.Set("base64", base64Str)
 		r = img.WithCustomData(true)
 	}
 
 	return records, nil
+}
+
+func (s *ImageStore) getRawImageBase64(img *db.Image) (*string, error) {
+	buf, err := s.getRawImage(img)
+	if err != nil {
+		return nil, err
+	}
+	base64Str := base64.StdEncoding.EncodeToString(buf.Bytes())
+	return &base64Str, nil
 }
 
 func (s *ImageStore) getRawImage(img *db.Image) (*bytes.Buffer, error) {
@@ -79,4 +116,13 @@ func (s *ImageStore) getRawImage(img *db.Image) (*bytes.Buffer, error) {
 	}
 
 	return content, err
+}
+
+func (s *ImageStore) newFile(base64Str *string) (*filesystem.File, error) {
+	buf, err := base64.StdEncoding.DecodeString(*base64Str)
+	if err != nil {
+		return nil, err
+	}
+
+	return filesystem.NewFileFromBytes(buf, security.RandomString(16))
 }

--- a/server/store/posts.go
+++ b/server/store/posts.go
@@ -47,6 +47,18 @@ func (d *PostStore) CreatePost(auth *core.Record, data *model.CreatePostRequest)
 	post.SetUpdatedBy(auth.Id)
 	post.SetActive(true)
 
+	imageIds := []string{}
+	for _, image := range data.Images {
+		img, err := d.imageStore.CreateImage(auth, &image.Base64, image.Order)
+		if err != nil {
+			return nil, err
+		} else {
+			imageIds = append(imageIds, img.Id)
+		}
+	}
+
+	post.SetImages(&imageIds)
+
 	if err = app.Save(post); err != nil {
 		return nil, err
 	}
@@ -63,7 +75,7 @@ func (s *PostStore) GetPosts(take, skip int) ([]*core.Record, error) {
 		"-"+db.Post_Created,
 		take,
 		skip,
-		dbx.Params{db.Post_Active: true})
+		dbx.Params{"active": true})
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- Fügt die Möglichkeit hinzu, Bilder als Base64 zu speichern
- Implementiert das Setzen und Abrufen von Bildern in Posts
- Ermöglicht das Erstellen von Bildern über eine API-Anfrage
- Verbessert die Handhabung von Bilddaten im ImageStore