### PR TITLE
Benutzer-Avatar hinzufügen und abrufen

### DIFF
--- a/server/api/users.go
+++ b/server/api/users.go
@@ -102,7 +102,12 @@ func (a *UserApi) resetPassword(e *core.RequestEvent) error {
 }
 
 func (a *UserApi) getCurrentUser(e *core.RequestEvent) error {
-	return RecordResponse(e, e.Auth)
+	user, err := a.store.GetById(e.Auth.Id)
+	if err != nil {
+		return apis.NewInternalServerError("error_get_current_auth", err)
+	}
+
+	return RecordResponse(e, user.Record)
 }
 
 func (a *UserApi) getProfile(e *core.RequestEvent) error {

--- a/server/store/db/user.go
+++ b/server/store/db/user.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/filesystem"
 )
 
 var _ core.RecordProxy = (*User)(nil)
@@ -14,6 +15,7 @@ const User_Firstname = "firstname"
 const User_Lastname = "lastname"
 const User_Bio = "bio"
 const User_LockoutEnabled = "bio"
+const User_Avatar = "avatar"
 
 func (u *User) GetFirstname() string {
 	return u.GetString(User_Firstname)
@@ -45,4 +47,8 @@ func (u *User) GetLockoutEnabled() bool {
 
 func (u *User) SetLockoutEnabled(lockout bool) {
 	u.Set(User_LockoutEnabled, lockout)
+}
+
+func (p *Image) SetAvatar(f *filesystem.File) {
+	p.Set(User_Avatar, f)
 }

--- a/server/store/users.go
+++ b/server/store/users.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"pinking-go/server/api/model"
 	"pinking-go/server/store/db"
+	"pinking-go/server/utils"
 
 	"github.com/pocketbase/pocketbase/core"
 )
@@ -73,6 +74,15 @@ func (d *UserStore) GetById(id string) (*db.User, error) {
 
 	user := &db.User{}
 	user.SetProxyRecord(record)
+
+	if user.GetString(db.User_Avatar) != "" {
+		base64Str, err := utils.GetImageBase64(d.app, user.Record, db.User_Avatar)
+		if err != nil {
+			return nil, err
+		}
+		user.Set(db.User_Avatar, base64Str)
+		user.Record = user.WithCustomData(true)
+	}
 
 	return user, nil
 }

--- a/server/utils/file.go
+++ b/server/utils/file.go
@@ -1,0 +1,54 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/base64"
+	"io"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/filesystem"
+	"github.com/pocketbase/pocketbase/tools/security"
+)
+
+func GetImageBase64(app *core.App, r *core.Record, col string) (*string, error) {
+	buf, err := getFileBuffer(app, r, col)
+	if err != nil {
+		return nil, err
+	}
+	base64Str := base64.StdEncoding.EncodeToString(buf.Bytes())
+	return &base64Str, nil
+}
+
+func NewFile(base64Str *string) (*filesystem.File, error) {
+	buf, err := base64.StdEncoding.DecodeString(*base64Str)
+	if err != nil {
+		return nil, err
+	}
+
+	return filesystem.NewFileFromBytes(buf, security.RandomString(16))
+}
+
+func getFileBuffer(app *core.App, r *core.Record, col string) (*bytes.Buffer, error) {
+	a := (*app)
+
+	fsys, err := a.NewFilesystem()
+	if err != nil {
+		return nil, err
+	}
+	defer fsys.Close()
+
+	key := r.BaseFilesPath() + "/" + r.GetString(col)
+	reader, err := fsys.GetFile(key)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	content := new(bytes.Buffer)
+	_, err = io.Copy(content, reader)
+	if err != nil {
+		return nil, err
+	}
+
+	return content, err
+}


### PR DESCRIPTION
Fügt die Unterstützung für Benutzer-Avatare hinzu und optimiert die 
Bildverarbeitung durch die Einführung neuer Hilfsfunktionen. 
Die Avatar-Daten werden jetzt in Base64 konvertiert und 
in der Benutzeroberfläche angezeigt. Reduziert redundanten 
Code in der Bildverarbeitung.