### PR TITLE
Füge Avatar-Funktionen hinzu

### DIFF
--- a/server/store/db/user.go
+++ b/server/store/db/user.go
@@ -49,8 +49,16 @@ func (u *User) SetLockoutEnabled(lockout bool) {
 	u.Set(User_LockoutEnabled, lockout)
 }
 
+func (p *User) GetAvatar() string {
+	return p.GetString(User_Avatar)
+}
+
 func (p *User) SetAvatar(f *filesystem.File) {
 	p.Set(User_Avatar, f)
+}
+
+func (p *User) SetAvatarBase64(base64Str *string) {
+	p.Set(User_Avatar, *base64Str)
 }
 
 func (p *User) ClearAvatar() {

--- a/server/store/users.go
+++ b/server/store/users.go
@@ -170,7 +170,19 @@ func (s *UserStore) GetPosters(relCollection *core.Collection, relIds []string) 
 	}
 
 	for _, r := range records {
-		r = r.Hide(db.User_Bio)
+		user := &db.User{}
+		user.SetProxyRecord(r)
+
+		if user.GetAvatar() != "" {
+			base64Str, err := utils.GetImageBase64(s.app, user.Record, db.User_Avatar)
+			if err != nil {
+				return nil, err
+			}
+			user.SetAvatarBase64(base64Str)
+		}
+
+		r = user.WithCustomData(true).
+			Hide(db.User_Bio)
 	}
 
 	return records, nil


### PR DESCRIPTION
- Implementiere GetAvatar zur Rückgabe des Avatars
- Füge SetAvatarBase64 hinzu, um Avatar von Base64-String zu setzen
- Aktualisiere GetPosters, um Avatar in Base64 zu laden
- Stelle sicher, dass Avatar-Daten korrekt verarbeitet werden